### PR TITLE
feat: improve skill review scores for 5 skills

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,22 @@
+# Tessl Skill Review — runs on PRs that change any SKILL.md; posts scores as one PR comment.
+# Docs: https://github.com/tesslio/skill-review
+name: Tessl Skill Review
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/SKILL.md"
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main
+      # Optional quality gate (off by default — do not enable unless user asked):
+      # with:
+      #   fail-threshold: 70

--- a/skills/code-style/SKILL.md
+++ b/skills/code-style/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-style
-description: "Enforce mirror, reuse, and symmetry principles to keep new code consistent with surrounding code. Use when writing new code in an existing codebase, adding new features, refactoring, or making any code changes."
+description: "Enforce mirror, reuse, and symmetry principles: match brace style, naming conventions, and spacing of surrounding code; reuse existing patterns and helpers instead of introducing new ones; maintain structural symmetry across parallel functions. Use when writing new code, adding features, refactoring, reviewing code style, or ensuring consistency with existing codebase patterns."
 ---
 
 # Code Style: Mirror, Reuse, Symmetry

--- a/skills/commit-rules/SKILL.md
+++ b/skills/commit-rules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit-rules
-description: "Shared commit message rules and technical constraints referenced by /stage-commit and /commit-staged. Not typically invoked directly."
+description: "Shared commit message rules and technical constraints: imperative mood, concise single-line messages matching existing style, no heredoc syntax, never bypass commit signing. Referenced by /stage-commit and /commit-staged. Use when the user asks about \"commit message format\", \"commit conventions\", \"how to write commit messages\", or \"commit style\"."
 ---
 
 # Commit Rules

--- a/skills/commit-staged/SKILL.md
+++ b/skills/commit-staged/SKILL.md
@@ -1,15 +1,25 @@
 ---
 name: commit-staged
-description: "Commit already-staged changes with a message matching existing commit style. Use when the user asks to \"commit staged changes\" or \"commit what's staged\"."
+description: "Commit already-staged changes with a message matching existing commit style, including validation that changes are actually staged. Use when the user asks to \"commit staged changes\", \"commit what's staged\", \"commit the staged files\", \"make a commit\", or \"commit this\"."
 ---
 
 # Commit Staged Changes
 
-## Step 1: Commit Rules
+## Step 1: Validate Staged Changes
+
+Run `git diff --cached --stat` to confirm changes are staged. If nothing is staged, inform the user and stop — do not create an empty commit.
+
+## Step 2: Commit Rules
 
 Run `/commit-rules` to load commit message rules and technical constraints.
 
-## Step 2: Commit
+## Step 3: Compose and Execute Commit
 
-- Changes are already staged and ready to commit
-- Do not stage any files
+- Do not stage any additional files — only commit what is already staged
+- Review the staged diff to write an accurate commit message
+- If the commit fails due to a pre-commit hook, read the hook output, fix the issue, re-stage, and retry
+- If commit signing fails, use `AskUserQuestion` to let the user resolve it
+
+## Step 4: Verify
+
+Run `git log -1 --oneline` to confirm the commit was created successfully.

--- a/skills/github-voice/SKILL.md
+++ b/skills/github-voice/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-voice
-description: "Shared writing style rules for GitHub-facing output (PR comments, PR descriptions, PR titles). Differentiates insider vs outsider voice based on author association. Not typically invoked directly — loaded by other skills before composing GitHub text."
+description: "Shared writing style rules for GitHub-facing output: natural tone, no em dashes, insider vs outsider voice based on author association. Loaded by other skills before composing PR comments, PR descriptions, or PR titles. Use when writing GitHub text, composing PR descriptions, drafting issue comments, or adjusting tone for GitHub output."
 ---
 
 # GitHub Voice

--- a/skills/update-dependencies/SKILL.md
+++ b/skills/update-dependencies/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: update-dependencies
-description: "Upgrade project dependencies with breaking change research for major version updates. Use when the user asks to \"update dependencies\", \"upgrade packages\", \"upgrade dependencies\", \"update deps\", \"upgrade deps\", \"update npm deps\", \"update Swift packages\", \"cargo update\", \"go get updates\", \"bundle update\", or \"pip upgrade\"."
-argument-hint: "[package-filter]"
+description: "Upgrade project dependencies with breaking change research for major version updates: detect outdated packages, research migration guides, apply codemods, and verify with tests. Use when the user asks to \"update dependencies\", \"upgrade packages\", \"upgrade dependencies\", \"update deps\", \"upgrade deps\", \"update npm deps\", \"update Swift packages\", \"cargo update\", \"go get updates\", \"bundle update\", or \"pip upgrade\"."
+metadata:
+  argument-hint: "[package-filter]"
 ---
 
 # Update Dependencies
@@ -42,14 +43,15 @@ Identify all major versions between current and target. For example:
 
 ### Step 2: Research Each Major Version
 
-Search for migration documentation:
+Search for migration documentation using WebSearch:
 
-```
-WebSearch: "[package-name] v[X] migration guide"
-WebSearch: "[package-name] v[X] breaking changes"
+```bash
+# Example: researching React 17 → 19 upgrade
+WebSearch: "react v18 migration guide"
+WebSearch: "react v19 breaking changes"
 ```
 
-Common sources: GitHub releases page, official docs, changelog files.
+Check GitHub releases pages, official docs, and changelog files.
 
 ### Step 3: Extract Key Breaking Changes
 
@@ -91,16 +93,7 @@ Update the manifest file (version constraint) and run the install/resolve comman
 
 ### Step 1: Run Codemods (if Available)
 
-Some ecosystems provide automated migration tools:
-
-| Ecosystem | Migration tools |
-|---|---|
-| React | `npx react-codemod [transform]` |
-| Next.js | `npx @next/codemod [transform]` |
-| Jest | `npx jest-codemods` |
-| Angular | `npx ng update` |
-| Rust | `cargo fix` for edition migrations |
-| Python | `pyupgrade`, `python-modernize` |
+Check if the ecosystem provides automated migration tools (e.g., `npx react-codemod rename-unsafe-lifecycles`, `npx @next/codemod new-link`, `cargo fix`). Run them before manual changes.
 
 ### Step 2: Manual Code Changes
 


### PR DESCRIPTION
Hey @tobihagemann 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/59ffc910-f487-45f9-86fd-9ca6cce12a6f" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| commit-staged | 63% | 100% | +37% |
| code-style | 76% | 83% | +7% |
| update-dependencies | 76% | 81% | +5% |
| commit-rules | 79% | 91% | +12% |
| github-voice | 79% | 95% | +16% |

This PR intentionally caps changes at five skills to keep the review manageable. The included GitHub Action (see below) will surface Tessl feedback on future `SKILL.md` changes, so the rest of the library can improve incrementally.

<details>
<summary>Changes summary</summary>

- **commit-staged**: Added validation checkpoint (verify changes are staged before committing), error handling for hook failures and signing issues, and a post-commit verification step. This was the biggest win — the original was only 2 steps with no guardrails.
- **code-style**: Expanded description to list specific concrete actions (match brace style, reuse existing helpers, maintain structural symmetry) for better skill selection.
- **update-dependencies**: Moved `argument-hint` into `metadata` to fix unknown frontmatter key warning, replaced verbose codemod table with concise inline examples, added concrete WebSearch example.
- **commit-rules**: Added trigger terms and "Use when..." clause so Claude can select this skill when users ask about commit conventions directly.
- **github-voice**: Added trigger terms and "Use when..." clause for better discoverability when composing GitHub-facing text.

</details>

## Tessl Skill Review GitHub Action

This PR also adds `.github/workflows/skill-review.yml` — a lightweight GitHub Action that reviews skills automatically on PRs.

- **What runs:** On PRs that change `**/SKILL.md`, the workflow runs [`tesslio/skill-review`](https://github.com/tesslio/skill-review) and posts one comment with Tessl scores and feedback (updated on new pushes).
- **Zero extra accounts:** Contributors don't need a Tessl login — only `GITHUB_TOKEN` is used to post the comment.
- **Non-blocking by default:** The check is feedback-only with no surprise red CI unless you add `fail-threshold`.
- **Not a build replacement:** This is review automation for skill markdown, not a substitute for any build pipeline.
- **Optional gate:** Add `with: fail-threshold: 70` later if you want PRs to fail on low scores.
- **Why only five skills here:** This PR stays reviewable; after merge, every PR touching `SKILL.md` gets automatic review comments, so the rest of the library improves over time.

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
